### PR TITLE
feat: Add interactive pause/resume with state persistence

### DIFF
--- a/src/heimdall/browser/session.py
+++ b/src/heimdall/browser/session.py
@@ -365,6 +365,9 @@ class BrowserSession(BaseModel):
             chrome_args,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            # Start Chrome in its own process group so it doesn't receive SIGINT
+            # when user presses Ctrl+C (for pause/resume functionality)
+            start_new_session=True,
         )
 
         ws_url = await self._wait_for_cdp(port)

--- a/src/heimdall/cli.py
+++ b/src/heimdall/cli.py
@@ -134,6 +134,9 @@ def run(
                     console.print(f"Error: {error}")
             raise typer.Exit(1)
 
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Execution interrupted by user[/yellow]")
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1) from None
@@ -221,6 +224,8 @@ async def _run_agent(
                 save_trace_path=save_trace,
                 capture_screenshots=capture_screenshots,
                 use_collector=use_collector,
+                workspace_path=output_dir,
+                enable_persistence=True,
             ),
         )
 

--- a/src/heimdall/persistence/state.py
+++ b/src/heimdall/persistence/state.py
@@ -23,14 +23,40 @@ class TaskProgress(BaseModel):
 
 
 class PersistedState(BaseModel):
-    """Persistable agent state."""
+    """Persistable agent state for pause/resume functionality."""
 
+    # Session identification
+    session_id: str = ""
+
+    # Task state
     task: str = ""
     step_count: int = 0
     done: bool = False
-    actions_taken: list[dict] = Field(default_factory=list)
-    progress: TaskProgress = Field(default_factory=TaskProgress)
+    success: bool = False
+    error: str | None = None
+
+    # Execution state
+    consecutive_failures: int = 0
+    total_failures: int = 0
+
+    # Browser state
     last_url: str = ""
+
+    # History (serialized AgentHistoryList)
+    history: list[dict] = Field(default_factory=list)
+
+    # Actions taken (legacy compatibility)
+    actions_taken: list[dict] = Field(default_factory=list)
+
+    # Progress tracking
+    progress: TaskProgress = Field(default_factory=TaskProgress)
+
+    # Pause state
+    paused: bool = False
+
+    # Timestamps
+    started_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    paused_at: str | None = None
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
 


### PR DESCRIPTION
## Summary
Implements issue #4: State Persistence for Task Resumption

## Features
- **Ctrl+C** to pause execution and save state
- **Enter** to resume from where you left off  
- **Ctrl+C again** while paused to exit
- State automatically saved to `output/.heimdall_state.json`
- Auto-resume from saved state on next run with same task

## Changes
- Enhanced `PersistedState` model with session tracking, history, pause state
- Added SIGINT handler in `Agent.run()` using asyncio for safe pause
- Added `_handle_pause()` and `_save_state()` methods to Agent
- Start Chrome in its own process group (`start_new_session=True`) so it doesn't receive SIGINT
- Added `workspace_path` config for state persistence
- Handle KeyboardInterrupt gracefully in CLI

Closes #4